### PR TITLE
Added support for automagically replacing a diver's gear with "groundGear" once above water.

### DIFF
--- a/WL.VR/f/assignGear/fn_assignGearMan.sqf
+++ b/WL.VR/f/assignGear/fn_assignGearMan.sqf
@@ -7,8 +7,14 @@ _unit = _this select 0;
 if (!(local _unit)) exitWith {};
 
 _faction = tolower (faction _unit);
+
 //Check variable f_gear, otherwise default to typeof
 _loadout = _unit getVariable ["F_Gear", (typeOf _unit)];
+
+if (count _this > 1) then {
+    //Allow overriding unit loadout via call parameters
+    _loadout = [_this, 1, _loadout, [""]] call bis_fnc_param;
+};
 
 // INSIGNIA (todo: move to the CfgLoadouts system)
 // This block will give units insignia on their uniforms.

--- a/WL.VR/f/assignGear/fn_assignGearMan.sqf
+++ b/WL.VR/f/assignGear/fn_assignGearMan.sqf
@@ -195,4 +195,22 @@ if (isText _a) then {
     _unit call compile ("this = _this;"+ getText _a);
 };
 
+//Automatic ground gear for divers once they are above ground
+_groundClass = _path >> "groundClass";
+if (isText _groundClass) then {
+    [_unit, getText _groundClass] spawn {
+        private ["_unit"];
+
+        _unit = _this select 0;
+
+        waitUntil {sleep 0.02; vehicle _unit == _unit};
+        sleep 0.5;
+        waitUntil {sleep 0.02; !underwater _unit};;
+        waitUntil {sleep 0.02; isTouchingGround _unit};
+        sleep 1;
+
+        [_unit, _this select 1] call F_fnc_assignGearMan;
+    };
+};
+
 _unit setVariable ["f_var_assignGear_done", true, true];


### PR DESCRIPTION
This is a little gamey in its effect but we could make it so that once you are above land it gives you an addAction to switch into your ground gear and it has the player do a slow strip of diver gear into ground gear.

To use add the following parameter to a loadout class definition and name it's target as the loadout you want the unit to use once above ground.
```
class B_diver_F: B_Soldier_F {// Diver
        uniform[] = {"U_B_Wetsuit"};  /// randomized
        vest[] = {"V_RebreatherB"}; /// randomized
        backpack[] = {"B_Carryall_cbr"};
        headgear[] = {};

        backpackItems[] += {"U_B_CombatUniform_mcam","V_PlateCarrier1_rgr","H_HelmetB"};
        linkedItems[] += {"G_B_Diving"};
        groundGear = "B_Soldier_F";
};
```