### PR TITLE
Added Zeus support to F3 spectator.

### DIFF
--- a/WL.VR/f/spect/fn_EventHandler.sqf
+++ b/WL.VR/f/spect/fn_EventHandler.sqf
@@ -193,6 +193,9 @@ case "KeyDown":
     _key = _args select 1;
     _handled = false;
     if(!isNull (findDisplay 49)) exitWith {if(_key == 1) then {true}};
+
+    [_args, "keydown"] call CBA_events_fnc_keyHandler;
+
     switch (_key) do
     {
         case 78: // numpad +
@@ -421,6 +424,9 @@ case "KeyUp":
 {
     if(!isNull (findDisplay 49)) exitWith {};
     _key = _args select 1;
+
+    [_args, "keyup"] call CBA_events_fnc_keyHandler;
+
     _handled = false;
     switch (_key) do
     {

--- a/WL.VR/f/spect/fn_ForceExit.sqf
+++ b/WL.VR/f/spect/fn_ForceExit.sqf
@@ -1,15 +1,4 @@
 f_cam_forcedExit = true;
 closeDialog 1;
-["f_spect_tags","onEachFrame"] call bis_fnc_removeStackedEventHandler;
-["f_spect_cams","onEachFrame"] call bis_fnc_removeStackedEventHandler;
-terminate f_cam_updatevalues_script;
-(call f_cam_GetCurrentCam) cameraEffect ["terminate","back"];
+call F_fnc_RemoveHandlers;
 hintSilent "Spectator system has been forcefully closed";
-{
-	_var = _x getVariable ["f_cam_fired_eventid",nil];
-	if(!isNil "_var") then
-	{
-		_x removeEventHandler ["fired",_var];
-	};
-
-} foreach (allunits + vehicles);

--- a/WL.VR/f/spect/fn_OnUnload.sqf
+++ b/WL.VR/f/spect/fn_OnUnload.sqf
@@ -41,8 +41,6 @@ waitUntil {sleep 0.1; scriptDone _handle};
 // Allow handler to take control over re-init
 if (f_cam_specialExit) ExitWith {};
 
-player globalChat "RE-LOADING SPEC";
-
 createDialog "f_spec_dialog";
 
 _displayDialog = (findDisplay 9228);

--- a/WL.VR/f/spect/fn_OnUnload.sqf
+++ b/WL.VR/f/spect/fn_OnUnload.sqf
@@ -1,6 +1,48 @@
 disableSerialization;
 sleep 1;
 if (f_cam_forcedExit) ExitWith {};
+
+f_cam_specialExit = false;
+
+// handler to check for menus we want to wait on
+_handle = [] spawn {
+	// Zeus menus
+	if (!isNull (findDisplay 312)) then {
+		_done = false;
+		waitUntil {sleep 0.1;!isNull (findDisplay 312)}; // wait until open
+
+		// disable all the rendering from spect while in Zeus
+		call F_fnc_RemoveHandlers;
+		f_cam_specialExit = true;
+
+		while {!_done} do
+		{
+		    waitUntil {sleep 0.1;isNull (findDisplay 312)}; // then wait until its not open
+		    if(isnil "bis_fnc_moduleRemoteControl_unit") then // check if someone is being remote controled
+		    {
+		    	[player,player,player,0,true] spawn F_fnc_CamInit;
+		        _done = true;
+		    }; // restart spectator once exit.
+		};
+	};
+	// Pause menu
+	if (!isNull (findDisplay 49)) then {
+		waitUntil {sleep 0.1; isNull (findDisplay 49)}; // then wait until its not open
+	};
+	// Pabst Menu
+	if (!isNull (uiNamespace getVariable "PABST_ADMIN_dialogControl")) then {
+		_idc = ctrlIDD (uiNamespace getVariable "PABST_ADMIN_dialogControl");
+		waitUntil {sleep 0.1; isNull (findDisplay _idc)};
+	};
+};
+
+waitUntil {sleep 0.1; scriptDone _handle};
+
+// Allow handler to take control over re-init
+if (f_cam_specialExit) ExitWith {};
+
+player globalChat "RE-LOADING SPEC";
+
 createDialog "f_spec_dialog";
 
 _displayDialog = (findDisplay 9228);

--- a/WL.VR/f/spect/fn_RemoveHandlers.sqf
+++ b/WL.VR/f/spect/fn_RemoveHandlers.sqf
@@ -1,0 +1,11 @@
+["f_spect_tags","onEachFrame"] call bis_fnc_removeStackedEventHandler;
+["f_spect_cams","onEachFrame"] call bis_fnc_removeStackedEventHandler;
+terminate f_cam_updatevalues_script;
+{
+	_var = _x getVariable ["f_cam_fired_eventid",nil];
+	if(!isNil "_var") then
+	{
+		_x removeEventHandler ["fired",_var];
+	};
+
+} foreach (allunits + vehicles);

--- a/WL.VR/f/spect/functions.hpp
+++ b/WL.VR/f/spect/functions.hpp
@@ -14,6 +14,7 @@ class fspectator
 	class OnMapClick{};
 	class DrawMarkers{};
 	class ForceExit{};
+	class RemoveHandlers{};
 	class HandleMenu{};
 	class showMenu{};
 };


### PR DESCRIPTION
It also has logic for waiting to re-initialize the spectator menu until the pause menu, zeus menu, or admin menu is closed.

Oh and it passes through key presses into the cba keyhandlers so that things like the ACRE2 mute spectator speakers key still works while in spect.