### PR TITLE
Fixed custom factions OPFOR loadouts causing CTD

### DIFF
--- a/Custom Factions/OPFOR/CSAT/opfor_standard.hpp
+++ b/Custom Factions/OPFOR/CSAT/opfor_standard.hpp
@@ -1,18 +1,18 @@
-//Author: 
+//Author:
 //Description: OPFOR (CSAT) Standard
 
 class opf_f {
     //Rifle
     #define EAST_RIFLE "arifle_Katiba_F"
     #define EAST_RIFLE_MAG "30Rnd_65x39_caseless_green:8","30Rnd_65x39_caseless_green_mag_Tracer:2"
-    
+
 	//GL Rifle
     #define EAST_GLRIFLE "arifle_Katiba_GL_F"
     #define EAST_GLRIFLE_MAG "30Rnd_65x39_caseless_green:8","30Rnd_65x39_caseless_green_mag_Tracer:2"
     #define EAST_GLRIFLE_MAG_SMOKE "1Rnd_Smoke_Grenade_shell:4","1Rnd_SmokeGreen_Grenade_shell:1","1Rnd_SmokeRed_Grenade_shell:2"
     #define EAST_GLRIFLE_MAG_HE "1Rnd_HE_Grenade_shell:10"
     #define EAST_GLRIFLE_MAG_FLARE "UGL_FlareWhite_F:2","UGL_FlareRed_F:2","UGL_FlareWhite_F:2","UGL_FlareGreen_F:2"
-    
+
 	//Carbine
     #define EAST_CARBINE "arifle_Katiba_C_F"
     #define EAST_CARBINE_MAG "30Rnd_65x39_caseless_green:8","30Rnd_65x39_caseless_green_mag_Tracer:2"
@@ -20,40 +20,40 @@ class opf_f {
     //Diver
     #define SDAR "arifle_SDAR_F"
     #define SDAR_MAG "20Rnd_556x45_UW_mag:6"
-    
+
 	// AR
     #define EAST_AR "LMG_Zafir_F"
     #define EAST_AR_MAG "150Rnd_762x54_Box:5"
     #define EAST_AR_MAG2 "150Rnd_762x54_Box_Tracer:4"
-    
+
 	// AT
     #define EAST_AT "launch_RPG32_F"
     #define EAST_AT_MAG "RPG32_HE_F","RPG32_F"
-    
+
 	// MMG
     #define EAST_MMG "MMG_01_hex_F"
     #define EAST_MMG_MAG "150Rnd_93x64_Mag:5"
-    
+
 	// MAT
     #define EAST_MAT "launch_O_Titan_short_F"
     #define EAST_MAT_MAG "Titan_AT:2","Titan_AP:2"
-    
+
 	// SAM
     #define EAST_SAM "launch_O_Titan_F"
     #define EAST_SAM_MAG "Titan_AA:2"
-    
+
 	// Sniper Rifle
     #define EAST_SNIPER "srifle_DMR_01_F"
     #define EAST_SNIPER_MAG "10Rnd_762x54_Mag:8"
-    
+
 	// Spotter Rifle
     #define EAST_SPOTTER "arifle_Katiba_F"
     #define EAST_SPOTTER_MAG "30Rnd_65x39_caseless_green:8"
-    
+
 	// SMG
     #define EAST_SMG "SMG_02_F"
     #define EAST_SMG_MAG "30Rnd_9x21_Mag:5"
-    
+
 	// Pistol
     #define EAST_PISTOL "hgun_Rook40_F"
     #define EAST_PISTOL_MAG "16Rnd_9x21_Mag:4"
@@ -71,24 +71,24 @@ class opf_f {
         TransportMagazines[] = {EAST_RIFLE_MAG,EAST_RIFLE_MAG,EAST_CARBINE_MAG,EAST_AR_MAG,EAST_AR_MAG,EAST_GLRIFLE_MAG_HE,EAST_AT_MAG};
         TransportItems[] = {"ACE_fieldDressing:12","ACE_morphine:4"};
     };
-	
+
     class Tank {
         TransportMagazines[] = {EAST_RIFLE_MAG,EAST_RIFLE_MAG,EAST_CARBINE_MAG,EAST_AR_MAG,EAST_AR_MAG,EAST_GLRIFLE_MAG_HE,EAST_AT_MAG};
         TransportItems[] = {"ACE_fieldDressing:12","ACE_morphine:4"};
     };
-	
+
     class Helicopter {
         TransportMagazines[] = {};
     };
-	
+
     class Plane {
         TransportMagazines[] = {};
     };
-	
+
     class Ship_F {
         TransportMagazines[] = {};
     };
-	
+
 // ====================================================================================
 // Leadership INF and Groupies
 
@@ -106,7 +106,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         attachments[] = {"optic_Hamr"};
     };
-	
+
     class O_officer_F: O_Soldier_F { // CO and DC
         weapons[] = {EAST_GLRIFLE};
         //vest[] = {"rhsusf_iotv_ocp_Grenadier"}; /// randomized
@@ -117,13 +117,13 @@ class opf_f {
         backpackItems[] += {"ACE_key_east","ACRE_PRC117F"};
         items[] = {"ACE_MapTools", "ACRE_PRC148"};
     };
-	
+
     class O_soldier_SL_F: O_Officer_F { // SL
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","ACRE_PRC343","NVGoggles","ItemGPS","Binocular"};
         items[] = {"ACE_MapTools","ACRE_PRC148", "ACRE_PRC343"};
         backpackItems[] = {"ACE_fieldDressing:4","ACE_morphine","ACE_IR_Strobe_item","ACE_earplugs"};
     };
-	
+
     class O_soldier_UAV_F: O_Soldier_F {
         backpack[] = {"O_UAV_01_backpack_F"}; /// randomized
         linkedItems[] += {"O_uavterminal"};
@@ -135,10 +135,10 @@ class opf_f {
         magazines[] = {EAST_CARBINE_MAG,EAST_SMOKE_WHITE};
         backpackItems[] = {"ACE_fieldDressing:31","ACE_epinephrine:8","ACE_bloodIV:2","ACE_morphine:14","ACE_earplugs"};
     };
-	
+
 // ====================================================================================
-// Grunt Infantry	
-	
+// Grunt Infantry
+
     class O_Soldier_TL_F: O_Soldier_F {// FTL
         weapons[] = {EAST_GLRIFLE};
         //headgear[] = {"rhsusf_ach_helmet_headset_ess_ocp"}; /// randomized
@@ -146,11 +146,11 @@ class opf_f {
         linkedItems[] += {"ItemGPS","Binocular"};
         backpackItems[] += {"ACE_key_east"};
     };
-	
+
     class O_soldier_GL_F: O_Soldier_TL_F { // SL
-    
+
 	};
-	
+
     class O_Soldier_AR_F: O_Soldier_F {// AR
         //vest[] = {"rhsusf_iotv_ocp_SAW"}; /// randomized
         weapons[] = {EAST_AR};
@@ -158,7 +158,7 @@ class opf_f {
         handguns[] = {EAST_PISTOL}; /// randomized
         attachments[] = {};
     };
-	
+
     class O_Soldier_AAR_F: O_Soldier_F {// AAR
         backpackItems[] += {EAST_AR_MAG2};
         attachments[] = {"optic_Hamr"};
@@ -168,29 +168,29 @@ class opf_f {
     class O_Soldier_A_F: O_Soldier_AAR_F {// AAR
 
     };
-	
+
     class O_Soldier_LAT_F: O_Soldier_F {// RAT
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_AT_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         launchers[] = {EAST_AT}; /// randomized
     };
-	
+
 
 // ====================================================================================
 // Support Infantry
- 	
+
     class O_support_MG_F: O_Soldier_F {// MMG
         weapons[] = {EAST_MMG};
         magazines[] = {EAST_MMG_MAG,EAST_PISTOL_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         handguns[] = {EAST_PISTOL}; /// randomized
     };
-	
+
     class O_Support_AMG_F: O_Soldier_F {// MMG Spotter/Ammo Bearer
         backpackItems[] += {EAST_MMG_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_soldier_AT_F: O_Soldier_F {// MAT Gunner
         weapons[] = {EAST_CARBINE};
         backpack[] = {"B_Carryall_ocamo"};
@@ -199,41 +199,40 @@ class opf_f {
         backpackItems[] += {EAST_MAT_MAG};
         attachments[] = {"rhs_acc_1p63","rhs_acc_pgo7v","rhs_acc_dtk"};
     };
-	
+
     class O_Soldier_AAT_F: O_Soldier_F {// MAT Spotter/Ammo Bearer
         backpack[] = {"B_Carryall_ocamo"};
         backpackItems[] += {EAST_MAT_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_soldier_AA_F: O_Soldier_F {// SAM Gunner
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         launchers[] = {EAST_SAM}; /// randomized
         backpackItems[] += {EAST_SAM_MAG};
     };
-	
+
     class O_Soldier_AAA_F: O_Soldier_F {// SAM Spotter/Ammo Bearer
         backpackItems[] += {EAST_SAM_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_support_Mort_F: O_Soldier_F {// Mortar Gunner
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs"};
         backpack[] = {"O_Mortar_01_weapon_F"}; /// randomized
     };
-	
+
     class O_support_AMort_F: O_Soldier_F {// Assistant Mortar
         backpack[] = {"O_Mortar_01_support_F"}; /// randomized
-        items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs"};
+        items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs", "ACRE_PRC148"};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
     };
-	
+
     class O_spotter_F {// Spotter
         headgear[] = {"H_HelmetSpecO_ocamo"}; /// randomized
         uniform[] = {"U_O_GhillieSuit"};  /// randomized
@@ -244,7 +243,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS","LaserDesignator"};
         attachments[] = {"optic_Hamr"};
     };
-	
+
     class O_sniper_F {// Sniper
         headgear[] = {"H_HelmetSpecO_ocamo"}; /// randomized
         uniform[] = {"U_O_GhillieSuit"};  /// randomized
@@ -280,7 +279,7 @@ class opf_f {
         uniform[] = {"U_O_PilotCoveralls"};  /// randomized
         headgear[] = {"H_PilotHelmetFighter_O"}; /// randomized
     };
-	
+
     class O_crew_F {// Crew
         headgear[] = {"H_HelmetCrew_O"}; /// randomized
         uniform[] = {"U_O_SpecopsUniform_ocamo"};  /// randomized
@@ -293,7 +292,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS"};
         attachments[] = {};
     };
-	
+
     class O_soldier_repair_F: O_crew_F {// Repair Specialist
         backpack[] = {"B_Carryall_mcamo"};
         backpackItems[] = {"Toolkit", "ACE_fieldDressing:3","ACE_morphine","ACRE_PRC148","ACE_earplugs"};
@@ -302,14 +301,14 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         attachments[] = {};
     };
-	
+
     class O_soldier_exp_F: O_soldier_repair_F {// Mines Specialist
         backpack[] = {"B_Carryall_mcamo"};
         backpackItems[] = {"Toolkit","ACE_DefusalKit","ACE_Clacker","MineDetector"};
         magazines[] = {EAST_CARBINE_MAG,"ATMine_Range_Mag:2","APERSBoundingMine_Range_Mag:2","APERSMine_Range_Mag:2"};
         attachments[] = {};
     };
-	
+
     class O_engineer_F: O_soldier_repair_F {// Explosive Specialist
         backpack[] = {"B_Carryall_mcamo"};
         backpackItems[] = {"Toolkit","ACE_DefusalKit","ACE_Clacker","MineDetector"};

--- a/Custom Factions/OPFOR/Russia (VDV)/EMR/opfor_standard.hpp
+++ b/Custom Factions/OPFOR/Russia (VDV)/EMR/opfor_standard.hpp
@@ -1,18 +1,18 @@
-//Author: 
+//Author:
 //Description: OPFOR (CSAT) Standard
 
 class opf_f {
     //Rifle
     #define EAST_RIFLE "rhs_weap_ak74m_camo","rhs_weap_ak74m_2mag","rhs_weap_ak74m_2mag_camo","rhs_weap_ak74m","rhs_weap_ak74m_plummag"
     #define EAST_RIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
-    
+
 	//GL Rifle
     #define EAST_GLRIFLE "rhs_weap_ak74m_gp25"
     #define EAST_GLRIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
     #define EAST_GLRIFLE_MAG_SMOKE "rhs_GRD40_White:4","rhs_GRD40_Green:1","rhs_GRD40_Red:2"
     #define EAST_GLRIFLE_MAG_HE "rhs_VOG25:10"
     #define EAST_GLRIFLE_MAG_FLARE "rhs_VG40OP_white:2","rhs_VG40OP_red:2","rhs_VG40OP_white:2","rhs_VG40OP_green:2"
-    
+
 	//Carbine
     #define EAST_CARBINE "rhs_weap_ak74m_camo","rhs_weap_ak74m_2mag","rhs_weap_ak74m_2mag_camo","rhs_weap_ak74m","rhs_weap_ak74m_plummag"
     #define EAST_CARBINE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
@@ -20,40 +20,40 @@ class opf_f {
     //Diver
     #define SDAR "arifle_SDAR_F"
     #define SDAR_MAG "20Rnd_556x45_UW_mag:6"
-    
+
 	// AR
     #define EAST_AR "rhs_weap_pkp"
     #define EAST_AR_MAG "rhs_100Rnd_762x54mmR:5"
     #define EAST_AR_MAG2 "rhs_100Rnd_762x54mmR_green:4"
-    
+
 	// AT
     #define EAST_AT "rhs_weap_rpg26"
     #define EAST_AT_MAG "rhs_rpg26_mag","rhs_rpg26_mag"
-    
+
 	// MMG
     #define EAST_MMG "rhs_weap_pkp"
     #define EAST_MMG_MAG "rhs_100Rnd_762x54mmR:5"
-    
+
 	// MAT
     #define EAST_MAT "rhs_weap_rpg7"
     #define EAST_MAT_MAG "rhs_rpg7_PG7VR_mag:2","rhs_rpg7_TBG7V_mag:2"
-    
+
 	// SAM
     #define EAST_SAM "rhs_weap_igla"
     #define EAST_SAM_MAG "rhs_mag_9k38_rocket:2"
-    
+
 	// Sniper Rifle
     #define EAST_SNIPER "rhs_weap_svds"
     #define EAST_SNIPER_MAG "rhs_10Rnd_762x54mmR_7N1:8"
-    
+
 	// Spotter Rifle
     #define EAST_SPOTTER "rhs_weap_svds"
     #define EAST_SPOTTER_MAG "rhs_10Rnd_762x54mmR_7N1:8"
-    
+
 	// SMG
     #define EAST_SMG "rhs_weap_ak74m_folded"
     #define EAST_SMG_MAG "rhs_30Rnd_545x39_AK:5"
-    
+
 	// Pistol
     #define EAST_PISTOL "rhs_weap_pya"
     #define EAST_PISTOL_MAG "rhs_mag_9x19_17:4"
@@ -71,24 +71,24 @@ class opf_f {
         TransportMagazines[] = {EAST_RIFLE_MAG,EAST_RIFLE_MAG,EAST_CARBINE_MAG,EAST_AR_MAG,EAST_AR_MAG,EAST_GLRIFLE_MAG_HE,EAST_AT_MAG};
         TransportItems[] = {"ACE_fieldDressing:12","ACE_morphine:4"};
     };
-	
+
     class Tank {
         TransportMagazines[] = {EAST_RIFLE_MAG,EAST_RIFLE_MAG,EAST_CARBINE_MAG,EAST_AR_MAG,EAST_AR_MAG,EAST_GLRIFLE_MAG_HE,EAST_AT_MAG};
         TransportItems[] = {"ACE_fieldDressing:12","ACE_morphine:4"};
     };
-	
+
     class Helicopter {
         TransportMagazines[] = {};
     };
-	
+
     class Plane {
         TransportMagazines[] = {};
     };
-	
+
     class Ship_F {
         TransportMagazines[] = {};
     };
-	
+
 // ====================================================================================
 // Leadership INF and Groupies
 
@@ -106,7 +106,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         attachments[] = {"rhs_acc_1p63","rhs_acc_pkas","rhs_acc_dtk"};
     };
-	
+
     class O_officer_F: O_Soldier_F { // CO and DC
         weapons[] = {EAST_GLRIFLE};
         vest[] = {"rhs_vest_commander"}; /// randomized
@@ -117,21 +117,21 @@ class opf_f {
         backpackItems[] += {"ACE_key_east","ACRE_PRC117F"};
         items[] = {"ACE_MapTools", "ACRE_PRC148"};
     };
-	
+
     class O_soldier_SL_F: O_Officer_F { // SL
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","ACRE_PRC343","NVGoggles","ItemGPS","Binocular"};
         items[] = {"ACE_MapTools","ACRE_PRC148", "ACRE_PRC343"};
         backpackItems[] = {"ACE_fieldDressing:4","ACE_morphine","ACE_IR_Strobe_item","ACE_earplugs"};
     };
-	
+
     class O_soldier_UAV_F: O_Soldier_F {
         backpack[] = {"O_UAV_01_backpack_F"}; /// randomized
         linkedItems[] += {"O_uavterminal"};
     };
-	
+
 // ====================================================================================
-// Grunt Infantry		
-	
+// Grunt Infantry
+
     class O_Soldier_TL_F: O_Soldier_F {// FTL
         weapons[] = {EAST_GLRIFLE};
         headgear[] = {"rhs_6b28_green"}; /// randomized
@@ -139,11 +139,11 @@ class opf_f {
         linkedItems[] += {"ItemGPS","Binocular"};
         backpackItems[] += {"ACE_key_east"};
     };
-	
+
     class O_soldier_GL_F: O_Soldier_TL_F { // SL
-    
+
 	};
-	
+
     class O_Soldier_AR_F: O_Soldier_F {// AR
         //vest[] = {"rhsusf_iotv_ocp_SAW"}; /// randomized
         weapons[] = {EAST_AR};
@@ -151,45 +151,45 @@ class opf_f {
         handguns[] = {EAST_PISTOL}; /// randomized
         attachments[] = {};
     };
-	
+
     class O_Soldier_AAR_F: O_Soldier_F {// AAR
         backpackItems[] += {EAST_AR_MAG2};
         attachments[] = {"rhs_acc_ekp1"};
         linkedItems[] += {"Binocular"};
     };
-	
+
     class O_Soldier_A_F: O_Soldier_AAR_F {// AAR
 
-    };	
-	
+    };
+
     class O_Soldier_LAT_F: O_Soldier_F {// RAT
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_AT_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         launchers[] = {EAST_AT}; /// randomized
     };
-	
+
     class O_medic_F: O_Soldier_F {// Medic
         vest[] = {"rhs_6b23_digi_medic"}; /// randomized
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_SMOKE_WHITE};
         backpackItems[] = {"ACE_fieldDressing:31","ACE_epinephrine:8","ACE_bloodIV:2","ACE_morphine:14","ACE_earplugs"};
     };
-	
+
 // ====================================================================================
-// Support Infantry	
-	
+// Support Infantry
+
     class O_support_MG_F: O_Soldier_F {// MMG
         weapons[] = {EAST_MMG};
         magazines[] = {EAST_MMG_MAG,EAST_PISTOL_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         handguns[] = {EAST_PISTOL}; /// randomized
     };
-	
+
     class O_Support_AMG_F: O_Soldier_F {// MMG Spotter/Ammo Bearer
         backpackItems[] += {EAST_MMG_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_soldier_AT_F: O_Soldier_F {// MAT Gunner
         weapons[] = {EAST_CARBINE};
         backpack[] = {"rhs_assault_umbts"};
@@ -198,41 +198,40 @@ class opf_f {
         backpackItems[] += {EAST_MAT_MAG};
         attachments[] = {"rhs_acc_1p63","rhs_acc_pgo7v","rhs_acc_dtk"};
     };
-	
+
     class O_Soldier_AAT_F: O_Soldier_F {// MAT Spotter/Ammo Bearer
         backpack[] = {"rhs_assault_umbts"};
         backpackItems[] += {EAST_MAT_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_soldier_AA_F: O_Soldier_F {// SAM Gunner
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         launchers[] = {EAST_SAM}; /// randomized
         backpackItems[] += {EAST_SAM_MAG};
     };
-	
+
     class O_Soldier_AAA_F: O_Soldier_F {// SAM Spotter/Ammo Bearer
         backpackItems[] += {EAST_SAM_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_support_Mort_F: O_Soldier_F {// Mortar Gunner
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs"};
         backpack[] = {"O_Mortar_01_weapon_F"}; /// randomized
     };
-	
+
     class O_support_AMort_F: O_Soldier_F {// Assistant Mortar
         backpack[] = {"O_Mortar_01_support_F"}; /// randomized
-        items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs"};
+        items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs", "ACRE_PRC148"};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
     };
-	
+
     class O_spotter_F {// Spotter
         headgear[] = {"rhs_Booniehat_digi"}; /// randomized
         uniform[] = {"rhs_uniform_vdv_emr"};  /// randomized
@@ -243,7 +242,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS","LaserDesignator"};
         attachments[] = {"rhs_acc_pso1m2"};
     };
-	
+
     class O_sniper_F {// Sniper
         headgear[] = {"rhs_Booniehat_digi"}; /// randomized
         uniform[] = {"rhs_uniform_vdv_emr"};  /// randomized
@@ -254,10 +253,10 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS"};
         attachments[] = {"rhs_acc_pso1m2"};
     };
-	
+
 // ====================================================================================
-// Vehicle Infantry	
-	
+// Vehicle Infantry
+
     class O_Helipilot_F {// Pilot
         uniform[] = {"rhs_uniform_df15"};  /// randomized
         vest[] = {"V_TacVest_blk"}; /// randomized
@@ -270,7 +269,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS","NVgoggles"};
         attachments[] = {};
     };
-	
+
     class O_helicrew_F: O_Helipilot_F { // Pilot
 
     };
@@ -278,8 +277,8 @@ class opf_f {
     class O_Pilot_F: O_Helipilot_F { // Pilot
         uniform[] = {"U_O_PilotCoveralls"};  /// randomized
         headgear[] = {"H_PilotHelmetFighter_O"}; /// randomized
-    };	
-	
+    };
+
     class O_crew_F {// Crew
         headgear[] = {"rhs_6b28_green_ess_bala"}; /// randomized
         uniform[] = {"rhs_uniform_vdv_emr"};  /// randomized
@@ -292,7 +291,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS"};
         attachments[] = {};
     };
-	
+
     class O_soldier_repair_F: O_crew_F {// Repair Specialist
         //backpack[] = {"rhs_assault_umbts_engineer"};
         backpackItems[] = {"Toolkit", "ACE_fieldDressing:3","ACE_morphine","ACRE_PRC148","ACE_earplugs"};
@@ -302,21 +301,21 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         attachments[] = {};
     };
-	
+
     class O_soldier_exp_F: O_soldier_repair_F {// Mines Specialist
         //backpack[] = {"rhs_sidor"};
         backpackItems[] = {"Toolkit","ACE_DefusalKit","ACE_Clacker","MineDetector"};
         magazines[] = {EAST_CARBINE_MAG,"ATMine_Range_Mag:2","APERSBoundingMine_Range_Mag:2","APERSMine_Range_Mag:2"};
         attachments[] = {"rhs_acc_dtk"};
     };
-	
+
     class O_engineer_F: O_soldier_repair_F {// Explosive Specialist
         //backpack[] = {"rhs_sidor"};
         backpackItems[] = {"Toolkit","ACE_DefusalKit","ACE_Clacker","MineDetector"};
         magazines[] = {EAST_CARBINE_MAG,"DemoCharge_Remote_Mag:3","SatchelCharge_Remote_Mag:2"};
         attachments[] = {"rhs_acc_dtk"};
     };
-	
+
 // ====================================================================================
 // Special Infantry
 

--- a/Custom Factions/OPFOR/Russia (VDV)/Flora/opfor_standard.hpp
+++ b/Custom Factions/OPFOR/Russia (VDV)/Flora/opfor_standard.hpp
@@ -1,18 +1,18 @@
-//Author: 
+//Author:
 //Description: OPFOR (CSAT) Standard
 
 class opf_f {
     //Rifle
     #define EAST_RIFLE "rhs_weap_ak74m_camo","rhs_weap_ak74m_2mag","rhs_weap_ak74m_2mag_camo","rhs_weap_ak74m","rhs_weap_ak74m_plummag"
     #define EAST_RIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
-    
+
 	//GL Rifle
     #define EAST_GLRIFLE "rhs_weap_ak74m_gp25"
     #define EAST_GLRIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
     #define EAST_GLRIFLE_MAG_SMOKE "rhs_GRD40_White:4","rhs_GRD40_Green:1","rhs_GRD40_Red:2"
     #define EAST_GLRIFLE_MAG_HE "rhs_VOG25:10"
     #define EAST_GLRIFLE_MAG_FLARE "rhs_VG40OP_white:2","rhs_VG40OP_red:2","rhs_VG40OP_white:2","rhs_VG40OP_green:2"
-    
+
 	//Carbine
     #define EAST_CARBINE "rhs_weap_ak74m_camo","rhs_weap_ak74m_2mag","rhs_weap_ak74m_2mag_camo","rhs_weap_ak74m","rhs_weap_ak74m_plummag"
     #define EAST_CARBINE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
@@ -20,40 +20,40 @@ class opf_f {
     //Diver
     #define SDAR "arifle_SDAR_F"
     #define SDAR_MAG "20Rnd_556x45_UW_mag:6"
-    
+
 	// AR
     #define EAST_AR "rhs_weap_pkp"
     #define EAST_AR_MAG "rhs_100Rnd_762x54mmR:5"
     #define EAST_AR_MAG2 "rhs_100Rnd_762x54mmR_green:4"
-    
+
 	// AT
     #define EAST_AT "rhs_weap_rpg26"
     #define EAST_AT_MAG "rhs_rpg26_mag","rhs_rpg26_mag"
-    
+
 	// MMG
     #define EAST_MMG "rhs_weap_pkp"
     #define EAST_MMG_MAG "rhs_100Rnd_762x54mmR:5"
-    
+
 	// MAT
     #define EAST_MAT "rhs_weap_rpg7"
     #define EAST_MAT_MAG "rhs_rpg7_PG7VR_mag:2","rhs_rpg7_TBG7V_mag:2"
-    
+
 	// SAM
     #define EAST_SAM "rhs_weap_igla"
     #define EAST_SAM_MAG "rhs_mag_9k38_rocket:2"
-    
+
 	// Sniper Rifle
     #define EAST_SNIPER "rhs_weap_svds"
     #define EAST_SNIPER_MAG "rhs_10Rnd_762x54mmR_7N1:8"
-    
+
 	// Spotter Rifle
     #define EAST_SPOTTER "rhs_weap_ak74m_camo"
     #define EAST_SPOTTER_MAG "rhs_30Rnd_545x39_AK:8"
-    
+
 	// SMG
     #define EAST_SMG "rhs_weap_ak74m_folded"
     #define EAST_SMG_MAG "rhs_30Rnd_545x39_AK:5"
-    
+
 	// Pistol
     #define EAST_PISTOL "rhs_weap_pya"
     #define EAST_PISTOL_MAG "rhs_mag_9x19_17:4"
@@ -71,24 +71,24 @@ class opf_f {
         TransportMagazines[] = {EAST_RIFLE_MAG,EAST_RIFLE_MAG,EAST_CARBINE_MAG,EAST_AR_MAG,EAST_AR_MAG,EAST_GLRIFLE_MAG_HE,EAST_AT_MAG};
         TransportItems[] = {"ACE_fieldDressing:12","ACE_morphine:4"};
     };
-	
+
     class Tank {
         TransportMagazines[] = {EAST_RIFLE_MAG,EAST_RIFLE_MAG,EAST_CARBINE_MAG,EAST_AR_MAG,EAST_AR_MAG,EAST_GLRIFLE_MAG_HE,EAST_AT_MAG};
         TransportItems[] = {"ACE_fieldDressing:12","ACE_morphine:4"};
     };
-	
+
     class Helicopter {
         TransportMagazines[] = {};
     };
-	
+
     class Plane {
         TransportMagazines[] = {};
     };
-	
+
     class Ship_F {
         TransportMagazines[] = {};
     };
-	
+
 // ====================================================================================
 // Leadership INF and Groupies
 
@@ -106,7 +106,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         attachments[] = {"rhs_acc_1p63","rhs_acc_pkas","rhs_acc_dtk"};
     };
-	
+
     class O_officer_F: O_Soldier_F { // CO and DC
         weapons[] = {EAST_GLRIFLE};
         vest[] = {"rhs_6b23_6sh92_vog_headset"}; /// randomized
@@ -117,21 +117,21 @@ class opf_f {
         backpackItems[] += {"ACE_key_east","ACRE_PRC117F"};
         items[] = {"ACE_MapTools", "ACRE_PRC148"};
     };
-	
+
     class O_soldier_SL_F: O_Officer_F { // SL
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","ACRE_PRC343","NVGoggles","ItemGPS","Binocular"};
         items[] = {"ACE_MapTools","ACRE_PRC148", "ACRE_PRC343"};
         backpackItems[] = {"ACE_fieldDressing:4","ACE_morphine","ACE_IR_Strobe_item","ACE_earplugs"};
     };
-	
+
     class O_soldier_UAV_F: O_Soldier_F {
         backpack[] = {"O_UAV_01_backpack_F"}; /// randomized
         linkedItems[] += {"O_uavterminal"};
     };
-	
+
 // ====================================================================================
-// Grunt Infantry		
-	
+// Grunt Infantry
+
     class O_Soldier_TL_F: O_Soldier_F {// FTL
         weapons[] = {EAST_GLRIFLE};
         //headgear[] = {"rhsusf_ach_helmet_headset_ess_ocp"}; /// randomized
@@ -139,11 +139,11 @@ class opf_f {
         linkedItems[] += {"ItemGPS","Binocular"};
         backpackItems[] += {"ACE_key_east"};
     };
-	
+
     class O_soldier_GL_F: O_Soldier_TL_F { // SL
-    
+
 	};
-	
+
     class O_Soldier_AR_F: O_Soldier_F {// AR
         //vest[] = {"rhsusf_iotv_ocp_SAW"}; /// randomized
         weapons[] = {EAST_AR};
@@ -151,41 +151,41 @@ class opf_f {
         handguns[] = {EAST_PISTOL}; /// randomized
         attachments[] = {};
     };
-	
+
     class O_Soldier_AAR_F: O_Soldier_F {// AAR
         backpackItems[] += {EAST_AR_MAG2};
         attachments[] = {"rhs_acc_ekp1"};
         linkedItems[] += {"Binocular"};
     };
-	
+
     class O_Soldier_LAT_F: O_Soldier_F {// RAT
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_AT_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         launchers[] = {EAST_AT}; /// randomized
     };
-	
+
     class O_medic_F: O_Soldier_F {// Medic
         //vest[] = {"rhsusf_iotv_ocp_medic"}; /// randomized
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_SMOKE_WHITE};
         backpackItems[] = {"ACE_fieldDressing:31","ACE_epinephrine:8","ACE_bloodIV:2","ACE_morphine:14","ACE_earplugs"};
     };
-	
+
 // ====================================================================================
-// Support Infantry	
-	
+// Support Infantry
+
     class O_support_MG_F: O_Soldier_F {// MMG
         weapons[] = {EAST_MMG};
         magazines[] = {EAST_MMG_MAG,EAST_PISTOL_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         handguns[] = {EAST_PISTOL}; /// randomized
     };
-	
+
     class O_Support_AMG_F: O_Soldier_F {// MMG Spotter/Ammo Bearer
         backpackItems[] += {EAST_MMG_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_soldier_AT_F: O_Soldier_F {// MAT Gunner
         weapons[] = {EAST_CARBINE};
         backpack[] = {"rhs_assault_umbts"};
@@ -194,41 +194,40 @@ class opf_f {
         backpackItems[] += {EAST_MAT_MAG};
         attachments[] = {"rhs_acc_1p63","rhs_acc_pgo7v","rhs_acc_dtk"};
     };
-	
+
     class O_Soldier_AAT_F: O_Soldier_F {// MAT Spotter/Ammo Bearer
         backpack[] = {"rhs_assault_umbts"};
         backpackItems[] += {EAST_MAT_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_soldier_AA_F: O_Soldier_F {// SAM Gunner
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         launchers[] = {EAST_SAM}; /// randomized
         backpackItems[] += {EAST_SAM_MAG};
     };
-	
+
     class O_Soldier_AAA_F: O_Soldier_F {// SAM Spotter/Ammo Bearer
         backpackItems[] += {EAST_SAM_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_support_Mort_F: O_Soldier_F {// Mortar Gunner
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs"};
         backpack[] = {"O_Mortar_01_weapon_F"}; /// randomized
     };
-	
+
     class O_support_AMort_F: O_Soldier_F {// Assistant Mortar
         backpack[] = {"O_Mortar_01_support_F"}; /// randomized
-        items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs"};
+        items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs", "ACRE_PRC148"};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
     };
-	
+
     class O_spotter_F {// Spotter
         headgear[] = {"rhs_Booniehat_flora","rhs_fieldcap"}; /// randomized
         uniform[] = {"rhs_uniform_flora"};  /// randomized
@@ -239,7 +238,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS","LaserDesignator"};
         attachments[] = {"rhs_acc_pso1m2"};
     };
-	
+
     class O_sniper_F {// Sniper
         headgear[] = {"rhs_Booniehat_flora","rhs_fieldcap"}; /// randomized
         uniform[] = {"rhs_uniform_flora"};  /// randomized
@@ -250,10 +249,10 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS"};
         attachments[] = {"rhs_acc_pso1m2"};
     };
-	
+
 // ====================================================================================
-// Vehicle Infantry	
-	
+// Vehicle Infantry
+
     class O_Helipilot_F {// Pilot
         uniform[] = {"rhs_uniform_df15"};  /// randomized
         vest[] = {"V_TacVest_blk"}; /// randomized
@@ -266,7 +265,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS","NVgoggles"};
         attachments[] = {};
     };
-	
+
     class O_helicrew_F: O_Helipilot_F { // Pilot
 
     };
@@ -274,8 +273,8 @@ class opf_f {
     class O_Pilot_F: O_Helipilot_F { // Pilot
         uniform[] = {"U_O_PilotCoveralls"};  /// randomized
         headgear[] = {"H_PilotHelmetFighter_O"}; /// randomized
-    };	
-	
+    };
+
     class O_crew_F {// Crew
         headgear[] = {"rhs_uniform_flora"}; /// randomized
         uniform[] = {"rhs_6b23_engineer"};  /// randomized
@@ -288,7 +287,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS"};
         attachments[] = {};
     };
-	
+
     class O_soldier_repair_F: O_crew_F {// Repair Specialist
         backpack[] = {"rhs_assault_umbts_engineer"};
         backpackItems[] = {"Toolkit", "ACE_fieldDressing:3","ACE_morphine","ACRE_PRC148","ACE_earplugs"};
@@ -298,21 +297,21 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         attachments[] = {};
     };
-	
+
     class O_soldier_exp_F: O_soldier_repair_F {// Mines Specialist
         backpack[] = {"rhs_sidor"};
         backpackItems[] = {"Toolkit","ACE_DefusalKit","ACE_Clacker","MineDetector"};
         magazines[] = {EAST_CARBINE_MAG,"ATMine_Range_Mag:2","APERSBoundingMine_Range_Mag:2","APERSMine_Range_Mag:2"};
         attachments[] = {"rhs_acc_dtk"};
     };
-	
+
     class O_engineer_F: O_soldier_repair_F {// Explosive Specialist
         backpack[] = {"rhs_sidor"};
         backpackItems[] = {"Toolkit","ACE_DefusalKit","ACE_Clacker","MineDetector"};
         magazines[] = {EAST_CARBINE_MAG,"DemoCharge_Remote_Mag:3","SatchelCharge_Remote_Mag:2"};
         attachments[] = {"rhs_acc_dtk"};
     };
-	
+
 // ====================================================================================
 // Special Infantry
 

--- a/Custom Factions/OPFOR/SLA/opfor_standard.hpp
+++ b/Custom Factions/OPFOR/SLA/opfor_standard.hpp
@@ -1,17 +1,17 @@
-//Author: 
+//Author:
 //Description: OPFOR (CSAT) Standard
 
 class opf_f {
     //Rifle
     #define EAST_RIFLE "rhs_weap_akm"
     #define EAST_RIFLE_MAG "rhs_30Rnd_762x39mm:8","rhs_30Rnd_762x39mm_tracer:2"
-    
+
 	//GL Rifle
     #define EAST_GLRIFLE "rhs_weap_akm_gp25"
     #define EAST_GLRIFLE_MAG "rhs_30Rnd_762x39mm:8","rhs_30Rnd_762x39mm_tracer:2"
     #define EAST_GLRIFLE_MAG_SMOKE "rhs_GRD40_White:4","rhs_GRD40_Green:2","rhs_GRD40_Red:3"
     #define EAST_GLRIFLE_MAG_HE "rhs_VOG25P:14"
-    
+
 	//Carbine
     #define EAST_CARBINE "rhs_weap_akms"
     #define EAST_CARBINE_MAG "rhs_30Rnd_762x39mm:8","rhs_30Rnd_762x39mm_tracer:2"
@@ -19,44 +19,44 @@ class opf_f {
     //Diver
     #define SDAR "arifle_SDAR_F"
     #define SDAR_MAG "20Rnd_556x45_UW_mag:6"
-    
+
 	// AR
     #define EAST_AR "rhs_weap_pkm"
     #define EAST_AR_MAG "rhs_100Rnd_762x54mmR:9"
     #define EAST_AR_MAG2 "rhs_100Rnd_762x54mmR_green:5"
-    
+
 	// AT
     #define EAST_AT "ibr_rpg7v"
     #define EAST_AT_MAG "ibr_pg7v:3"
-    
+
 	// MMG
     #define EAST_MMG "rhs_weap_pkm"
     #define EAST_MMG_MAG "rhs_100Rnd_762x54mmR:5"
-    
+
 	// MAT
     #define EAST_MAT "ibr_rpg7v"
     #define EAST_MAT_MAG "ibr_pg7v:1","ibr_og7:2"
-    
+
 	// SAM
     #define EAST_SAM "rhs_weap_igla"
     #define EAST_SAM_MAG "rhs_mag_9k38_rocket:2"
-   
+
     // Sniper Rifle
     #define EAST_SNIPER "rhs_weap_svdp_pso1"
     #define EAST_SNIPER_MAG "rhs_10Rnd_762x54mmR_7N1:8"
-    
+
 	// Spotter Rifle
     #define EAST_SPOTTER "hlc_rifle_aek971"
     #define EAST_SPOTTER_MAG "hlc_30Rnd_545x39_B_AK:8"
-    
+
 	// SMG
     #define EAST_SMG "rhs_weap_ak74m"
     #define EAST_SMG_MAG "rhs_30Rnd_545x39_AK:6"
-    
+
 	// Pistol
     #define EAST_PISTOL "rhsusf_weap_m1911a1"
     #define EAST_PISTOL_MAG "rhsusf_mag_7x45acp_MHP:4"
-	
+
 	// Grenades, Smoke and Frag
     #define EAST_GRENADE "rhs_mag_m67:2"
     #define EAST_SMOKE_WHITE "rhs_mag_an_m8hc:2"
@@ -70,24 +70,24 @@ class opf_f {
         TransportMagazines[] = {EAST_RIFLE_MAG,EAST_RIFLE_MAG,EAST_CARBINE_MAG,EAST_AR_MAG,EAST_AR_MAG,EAST_GLRIFLE_MAG_HE,EAST_AT_MAG};
         TransportItems[] = {"ACE_fieldDressing:12","ACE_morphine:4"};
     };
-	
+
     class Tank {
         TransportMagazines[] = {EAST_RIFLE_MAG,EAST_RIFLE_MAG,EAST_CARBINE_MAG,EAST_AR_MAG,EAST_AR_MAG,EAST_GLRIFLE_MAG_HE,EAST_AT_MAG};
         TransportItems[] = {"ACE_fieldDressing:12","ACE_morphine:4"};
     };
-	
+
     class Helicopter {
         TransportMagazines[] = {};
     };
-	
+
     class Plane {
         TransportMagazines[] = {};
     };
-	
+
     class Ship_F {
         TransportMagazines[] = {};
     };
-	
+
 // ====================================================================================
 // Leadership INF and Groupies
 
@@ -105,7 +105,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         attachments[] = {""};
     };
-	
+
     class O_officer_F: O_Soldier_F { // CO and DC
         weapons[] = {EAST_GLRIFLE};
         //vest[] = {"rhsusf_iotv_ocp_Grenadier"}; /// randomized
@@ -116,21 +116,21 @@ class opf_f {
         backpackItems[] += {"ACE_key_east","ACRE_PRC117F"};
         items[] = {"ACE_MapTools", "ACRE_PRC148"};
     };
-	
+
     class O_soldier_SL_F: O_Officer_F { // SL
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","ACRE_PRC343","NVGoggles","ItemGPS","Binocular"};
         items[] = {"ACE_MapTools","ACRE_PRC148", "ACRE_PRC343"};
         backpackItems[] = {"ACE_fieldDressing:4","ACE_morphine","ACE_IR_Strobe_item","ACE_earplugs"};
     };
-	
+
     class O_soldier_UAV_F: O_Soldier_F {
         backpack[] = {"O_UAV_01_backpack_F"}; /// randomized
         linkedItems[] += {"O_uavterminal"};
     };
-	
+
 // ====================================================================================
-// Grunt Infantry		
-	
+// Grunt Infantry
+
     class O_Soldier_TL_F: O_Soldier_F {// FTL
         weapons[] = {EAST_GLRIFLE};
         //headgear[] = {"rhsusf_ach_helmet_headset_ess_ocp"}; /// randomized
@@ -138,11 +138,11 @@ class opf_f {
         linkedItems[] += {"ItemGPS","Binocular"};
         backpackItems[] += {"ACE_key_east"};
     };
-	
+
     class O_soldier_GL_F: O_Soldier_TL_F { // SL
-    
+
 	};
-	
+
     class O_Soldier_AR_F: O_Soldier_F {// AR
         //vest[] = {"rhsusf_iotv_ocp_SAW"}; /// randomized
         weapons[] = {EAST_AR};
@@ -150,23 +150,23 @@ class opf_f {
         handguns[] = {EAST_PISTOL}; /// randomized
         attachments[] = {};
     };
-	
+
     class O_Soldier_AAR_F: O_Soldier_F {// AAR
         backpackItems[] += {EAST_AR_MAG2};
         attachments[] = {""};
         linkedItems[] += {"Binocular"};
     };
-	
+
     class O_Soldier_A_F: O_Soldier_AAR_F {// AAR
 
-    };	
-	
+    };
+
     class O_Soldier_LAT_F: O_Soldier_F {// RAT
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_AT_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         launchers[] = {EAST_AT}; /// randomized
     };
-	
+
     class O_medic_F: O_Soldier_F {// Medic
         //vest[] = {"rhsusf_iotv_ocp_medic"}; /// randomized
 		backpack[] = {"B_Carryall_oli","B_Carryall_mcamo"};
@@ -174,24 +174,24 @@ class opf_f {
         magazines[] = {EAST_CARBINE_MAG,EAST_SMOKE_WHITE};
         backpackItems[] = {"ACE_fieldDressing:31","ACE_epinephrine:8","ACE_bloodIV:2","ACE_morphine:14","ACE_earplugs"};
     };
-	
+
 // ====================================================================================
-// Support Infantry	
-	
+// Support Infantry
+
     class O_support_MG_F: O_Soldier_F {// MMG
         weapons[] = {EAST_MMG};
 		backpack[] = {"B_Carryall_oli","B_Carryall_mcamo"};
         magazines[] = {EAST_MMG_MAG,EAST_PISTOL_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         handguns[] = {EAST_PISTOL}; /// randomized
     };
-	
+
     class O_Support_AMG_F: O_Soldier_F {// MMG Spotter/Ammo Bearer
 		backpack[] = {"B_Carryall_oli","B_Carryall_mcamo"};
         backpackItems[] += {EAST_MMG_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_soldier_AT_F: O_Soldier_F {// MAT Gunner
         weapons[] = {EAST_CARBINE};
         backpack[] = {"rhs_rpg_empty"};
@@ -200,14 +200,14 @@ class opf_f {
         backpackItems[] += {EAST_MAT_MAG};
         attachments[] = {"rhs_acc_1p63","rhs_acc_pgo7v","rhs_acc_dtk"};
     };
-	
+
     class O_Soldier_AAT_F: O_Soldier_F {// MAT Spotter/Ammo Bearer
         backpack[] = {"rhs_rpg_empty"};
         backpackItems[] += {EAST_MAT_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_soldier_AA_F: O_Soldier_F {// SAM Gunner
         weapons[] = {EAST_CARBINE};
 		backpack[] = {"B_Carryall_oli","B_Carryall_mcamo"};
@@ -215,28 +215,27 @@ class opf_f {
         launchers[] = {EAST_SAM}; /// randomized
         backpackItems[] += {EAST_SAM_MAG};
     };
-	
+
     class O_Soldier_AAA_F: O_Soldier_F {// SAM Spotter/Ammo Bearer
 		backpack[] = {"B_Carryall_oli","B_Carryall_mcamo"};
         backpackItems[] += {EAST_SAM_MAG};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
+        items[] += {"ACRE_PRC148"};
     };
-	
+
     class O_support_Mort_F: O_Soldier_F {// Mortar Gunner
         weapons[] = {EAST_CARBINE};
         magazines[] = {EAST_CARBINE_MAG,EAST_GRENADE,EAST_SMOKE_WHITE};
         items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs"};
         backpack[] = {"O_Mortar_01_weapon_F"}; /// randomized
     };
-	
+
     class O_support_AMort_F: O_Soldier_F {// Assistant Mortar
         backpack[] = {"O_Mortar_01_support_F"}; /// randomized
-        items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs"};
+        items[] = {"ACE_fieldDressing:3","ACE_morphine","ACE_earplugs", "ACRE_PRC148"};
         linkedItems[] += {"ACE_Vector"};
-        items[] += {"ACRE_PRC148"};	
     };
-	
+
     class O_spotter_F {// Spotter
         headgear[] = {"H_Bandanna_khk"}; /// randomized
         //uniform[] = {"U_O_GhillieSuit"};  /// randomized
@@ -247,7 +246,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS","LaserDesignator"};
         attachments[] = {"HLC_Optic_1p29"};
     };
-	
+
     class O_sniper_F {// Sniper
         headgear[] = {"H_Bandanna_khk"}; /// randomized
         //uniform[] = {"U_O_GhillieSuit"};  /// randomized
@@ -258,10 +257,10 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS"};
         attachments[] = {"rhs_acc_pso1m2"};
     };
-	
+
 // ====================================================================================
-// Vehicle Infantry	
-	
+// Vehicle Infantry
+
     class O_Helipilot_F {// Pilot
         //uniform[] = {"U_O_PilotCoveralls"};  /// randomized
         //vest[] = {"V_TacVest_blk"}; /// randomized
@@ -274,7 +273,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS","NVgoggles"};
         attachments[] = {};
     };
-	
+
     class O_helicrew_F: O_Helipilot_F { // Pilot
 
     };
@@ -282,8 +281,8 @@ class opf_f {
     class O_Pilot_F: O_Helipilot_F { // Pilot
         uniform[] = {"U_O_PilotCoveralls"};  /// randomized
         headgear[] = {"H_PilotHelmetFighter_O"}; /// randomized
-    };	
-	
+    };
+
     class O_crew_F {// Crew
         headgear[] = {"H_HelmetCrew_O"}; /// randomized
         //uniform[] = {"U_O_SpecopsUniform_ocamo"};  /// randomized
@@ -296,7 +295,7 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch","itemGPS"};
         attachments[] = {};
     };
-	
+
     class O_soldier_repair_F: O_crew_F {// Repair Specialist
         backpack[] = {"B_Carryall_oli","B_Carryall_mcamo"};
         backpackItems[] = {"Toolkit", "ACE_fieldDressing:3","ACE_morphine","ACRE_PRC148","ACE_earplugs"};
@@ -305,21 +304,21 @@ class opf_f {
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         attachments[] = {};
     };
-	
+
     class O_soldier_exp_F: O_soldier_repair_F {// Mines Specialist
         backpack[] = {"B_Carryall_oli","B_Carryall_mcamo"};
         backpackItems[] = {"Toolkit","ACE_DefusalKit","ACE_Clacker","MineDetector"};
         magazines[] = {EAST_CARBINE_MAG,"ATMine_Range_Mag:2","APERSBoundingMine_Range_Mag:2","APERSMine_Range_Mag:2"};
         attachments[] = {};
     };
-	
+
     class O_engineer_F: O_soldier_repair_F {// Explosive Specialist
         backpack[] = {"B_Carryall_oli","B_Carryall_mcamo"};
         backpackItems[] = {"Toolkit","ACE_DefusalKit","ACE_Clacker","MineDetector"};
         magazines[] = {EAST_CARBINE_MAG,"DemoCharge_Remote_Mag:3","SatchelCharge_Remote_Mag:2"};
         attachments[] = {};
     };
-	
+
 // ====================================================================================
 // Special Infantry
 
@@ -347,5 +346,5 @@ class opf_f {
         backpackItems[] += {/*"U_O_CombatUniform_ocamo","V_HarnessO_brn","H_HelmetO_ocamo"*/EAST_CARBINE};
         linkedItems[] += {"G_O_Diving"};
 
-    };	
+    };
 };


### PR DESCRIPTION
Fixed custom factions OPFOR loadouts causing CTD because of items[] += after items[] has already been set in the same class entry.

This fixes issue #285 
