### PR TITLE
Spawn gunners

### DIFF
--- a/WL.VR/description.ext
+++ b/WL.VR/description.ext
@@ -62,6 +62,7 @@ class Extended_InitPost_EventHandlers {
     };
     class Helicopter {
         class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
+        class F_spawnGunners { serverInit  = "_this spawn ws_fnc_spawnGunners;"; };
         class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Helicopter'] call F_fnc_assignGearVehicle;"; };
     };
     class Plane {
@@ -208,6 +209,14 @@ class Params
             default = 1;
             code = "f_var_radios = %1";
     };
+    class f_param_spawnGunners
+    {
+        title = "Spawn Gunners";
+        values[] = {0,1};
+        texts[] = {"Off","On"};
+        default = 1;
+        code = "f_param_spawnGunners = %1";
+    };
 
 // ============================================================================================
 /*
@@ -246,7 +255,7 @@ class Params
  		isGlobal = 0;						// Execute this only on the server
  		code = "f_param_timeOfDay = %1";
 	};
-	
+
     class f_param_headlessClient
     	{
 	        title = "Headless client";

--- a/WL.VR/f/common/fn_processParamsArray.sqf
+++ b/WL.VR/f/common/fn_processParamsArray.sqf
@@ -13,3 +13,5 @@ _paramArray = paramsArray;
 		publicVariable _paramName;
 	};
 } foreach _paramArray;
+
+if (isServer) then { f_var_setParams = true; publicVariable "f_var_setParams";};

--- a/WL.VR/mission.sqm
+++ b/WL.VR/mission.sqm
@@ -359,7 +359,7 @@ class Mission
 					id=18;
 					side="WEST";
 					vehicle="B_Soldier_SL_F";
-					player="PLAY CDG";
+					player="PLAYER COMMANDER";
 					leader=1;
 					rank="SERGEANT";
 					skill=0.60000002;
@@ -6331,6 +6331,7 @@ class Mission
 			leader=1;
 			skill=0.60000002;
 			text="VehNATO_TH1";
+			init="this setVariable [""f_var_spawnGunners"",true];";
 		};
 		class Item1
 		{
@@ -6360,6 +6361,7 @@ class Mission
 			leader=1;
 			skill=0.60000002;
 			text="VehNATO_TH2";
+			init="this setVariable [""f_var_spawnGunners"",true];";
 		};
 		class Item4
 		{
@@ -6370,6 +6372,7 @@ class Mission
 			leader=1;
 			skill=0.60000002;
 			text="VehNATO_TH3";
+			init="this setVariable [""f_var_spawnGunners"",true];";
 		};
 		class Item5
 		{
@@ -6380,6 +6383,7 @@ class Mission
 			leader=1;
 			skill=0.60000002;
 			text="VehNATO_TH4";
+			init="this setVariable [""f_var_spawnGunners"",true];";
 		};
 		class Item6
 		{
@@ -6390,6 +6394,7 @@ class Mission
 			leader=1;
 			skill=0.60000002;
 			text="VehNATO_TH5";
+			init="this setVariable [""f_var_spawnGunners"",true];";
 		};
 		class Item7
 		{
@@ -6400,6 +6405,7 @@ class Mission
 			leader=1;
 			skill=0.60000002;
 			text="VehNATO_TH6";
+			init="this setVariable [""f_var_spawnGunners"",true];";
 		};
 		class Item8
 		{
@@ -6410,6 +6416,7 @@ class Mission
 			leader=1;
 			skill=0.60000002;
 			text="VehNATO_TH7";
+			init="this setVariable [""f_var_spawnGunners"",true];";
 		};
 		class Item9
 		{
@@ -6420,6 +6427,7 @@ class Mission
 			leader=1;
 			skill=0.60000002;
 			text="VehNATO_TH8";
+			init="this setVariable [""f_var_spawnGunners"",true];";
 		};
 		class Item10
 		{

--- a/WL.VR/ws_fnc/config.hpp
+++ b/WL.VR/ws_fnc/config.hpp
@@ -45,6 +45,7 @@ class WS
 			class attachIR {};
 			class broadcast {};
 			class showIntro {};
+			class spawnGunners {};
 		};
 		class getPos
 		{

--- a/WL.VR/ws_fnc/misc/fn_spawnGunners.sqf
+++ b/WL.VR/ws_fnc/misc/fn_spawnGunners.sqf
@@ -1,0 +1,37 @@
+// ws_fnc_spawnGunners
+// By Zriel | st1arma.es
+/*
+FEATURE
+Spawn AI gunners on selected vehicles, if f_var_spawnGunners in the vehicle is true and if f_param_spawnGunners is true also.
+USAGE
+
+[object] call ws_fnc_spawnGunners
+
+PARAMETERS
+1. The object (vehicle) to spawn gunners on.  | MANDATORY
+
+RETURNS
+crew
+
+NOTE
+ARMA 3 only
+
+*/
+
+private ["_vehicle","_crew"];
+
+_vehicle = _this select 0;
+
+waitUntil {!isNil "f_var_setParams"};
+
+if (!(f_param_spawnGunners == 1) || !(local _vehicle) || !(_vehicle getVariable ["f_var_spawnGunners",false])) exitWith {};
+
+createVehicleCrew _vehicle;
+_crew = crew _vehicle;
+
+{
+   if ((assignedVehicleRole _x select 0 == "Turret") && (assignedVehicleRole _x select 1 select 0 == 0)) then {_vehicle deleteVehicleCrew _x; _crew = _crew - [_x];};
+    if (driver _vehicle == _x) then {_vehicle deleteVehicleCrew _x; _crew = _crew - [_x];};
+} forEach _crew;
+
+_crew;


### PR DESCRIPTION
Added a Spawn AI Gunners function for helicopters, controlled by a param in mission, and a variable for selecting vehicles (default is off)
This way, you can Spawn AI gunners into transport helis (IE UH80s) when you do not have enough people to fill those positions. Gives more realism and transport helis are not so vulnerable.