### PR TITLE
Forced Advanced flight off

### DIFF
--- a/WL.VR/description.ext
+++ b/WL.VR/description.ext
@@ -3,7 +3,7 @@
 //  "forceRotorLibSimulation" (0 - default,options based; 1 forced On; 2 forced Off)
 // MUST BE FORCED TO DEFAULT. DO NOT CHANGE THIS. JANI WILL BEAT YOU WITH A SPATULA. <- That legacy code.
 
-forceRotorLibSimulation = 0;
+forceRotorLibSimulation = 2;
 
 // ============================================================================================
 


### PR DESCRIPTION
Changed forceRotorLibSimulation from 0 to 2 in description.ext to prevent players from flying with the advanced flight model.