### PR TITLE
Fix for houdini units bug #359

### DIFF
--- a/WL.VR/f/respawn/respawn_init.sqf
+++ b/WL.VR/f/respawn/respawn_init.sqf
@@ -5,6 +5,13 @@ if (isServer) then {
   //Counters to allow for unique IDs of respawned players and groups.
   f_serverRespawnPlayerCounter = 1;
   f_serverRespawnGroupCounter = 1;
+  [] spawn {
+	waitUntil {time > 0};
+	//check if respawn marker exists, if it doesn't then create it
+	if (getMarkerColor "respawn" == "") then {
+		createMarker ["respawn",[0,0]];
+	};
+  };
 };
 
 if (hasInterface) then {


### PR DESCRIPTION
This fixes the houdini units bug by ensuring that if a respawn marker doesn't exist, it gets created.